### PR TITLE
remove v14.x

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
       DUNE_API_KEY: ${{ secrets.DUNE_API_KEY }}
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We are often experiencing errors with all three versions being built in parallel. Hopefully removing one of them helps.


See here
https://github.com/bh2smith/dune-client-ts/actions/runs/3184757198
and here
https://github.com/bh2smith/dune-client-ts/actions/runs/3184962657

both on main with:

<img width="502" alt="Screen Shot 2022-10-04 at 9 42 01 PM" src="https://user-images.githubusercontent.com/11778116/193911016-6b1c35d0-9470-4755-a40b-547e96dc91c7.png">
